### PR TITLE
Int idspace

### DIFF
--- a/AUTHORS.txt
+++ b/AUTHORS.txt
@@ -1,6 +1,6 @@
 David Rivest-Henault : Core development, inverse-consistent implementation, GPU
-Nicholas Dowson      : Initial developpement and support during the inverse-consistent implementation
-Maciej Golebiewski   : Greatly improved GPU implementation
+Nicholas Dowson      : Initial developpement and support during the inverse-consistent implementation. 
+Maciej Golebiewski   : Further improvements to GPU implementation
 Jeremy Coatelen      : First GPU implementation
 Daan Broekhuizen     : NPW implementation
 

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ If you use this program for scientific research, we would appreciate if you coul
 LICENSE
 -------
 
-Copyright (c) 2009-15 CSIRO. All rights reserved.
+Copyright (c) 2009-17 CSIRO. All rights reserved.
 
 For complete copyright, license and disclaimer of warranty information see LICENSE.txt file for details.
 
@@ -65,7 +65,7 @@ PRE-REQUISITES - SUMMARY
 
 The following packages need to be installed to build Mirorr:
  - CMake
- - ITK, v4.X recommanded.
+ - ITK, v4.X recommended.
  - Boost, components: program_options filesystem system
 
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,13 +1,5 @@
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} ${CMAKE_CURRENT_LIST_DIR}/CMakeConfig)
 
-# Not yet released:
-# option(USE_NPW "Activate support for Non Parametric Window (NPW) matching" ON)
-set(USE_NPW OFF)
-
-if (USE_NPW)
-  add_subdirectory(npw)
-endif(USE_NPW)
-
 add_subdirectory(mirorr)
 
 

--- a/src/mirorr/CMakeLists.txt
+++ b/src/mirorr/CMakeLists.txt
@@ -73,7 +73,7 @@ if( USE_OPENCL )
 endif( USE_OPENCL )
 
 #set( CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-unused-local-typedefs") #Turn off those anoying warning... (most of them won't solve: they're part of ITK V4)
-add_executable( mirorr mirorr.cxx ${VTK_MIRORR_SRC}) 
+add_executable( mirorr mirorr.cxx itkMirorrUtilities.cxx ${VTK_MIRORR_SRC}) 
 target_link_libraries( mirorr
   ${ITK_LIBRARIES}
   boost_program_options boost_filesystem boost_system boost_timer

--- a/src/mirorr/itkBlockMatcher.txx
+++ b/src/mirorr/itkBlockMatcher.txx
@@ -540,7 +540,7 @@ BlockMatcher<ImageType>
   {
     IndexType baseIndex = baseRegion.GetIndex();
     SizeType baseRegionSize = baseRegion.GetSize();
-    for (int ii = 0; ii < ImageType::ImageDimension; ++ii)
+    for (unsigned int ii = 0; ii < ImageType::ImageDimension; ++ii)
     {
       nNhoods[ii] = (baseRegionSize[ii] - this->m_BlockWidth)
           / this->m_NhoodGap + 1;
@@ -606,7 +606,7 @@ int BlockMatcher<ImageType>
 {
   int nNhoodsTotal = 1;
   SizeType regionSize = matchingRegion.GetSize();
-  for (int ii = 0; ii < ImageType::ImageDimension; ++ii) {
+  for (unsigned int ii = 0; ii < ImageType::ImageDimension; ++ii) {
     nNhoodsTotal *= regionSize[ii]
               / this->m_NhoodGap + 1;
   }
@@ -731,7 +731,7 @@ void BlockMatcher<ImageType>
     searchStart.Fill(0); //to be like a2k
     IndexType searchEnd;
 
-    for( int ii=0; ii<ImageType::ImageDimension; ++ii )
+    for( unsigned int ii=0; ii<ImageType::ImageDimension; ++ii )
       searchEnd[ii] =
           this->m_BaseImage->GetLargestPossibleRegion().GetSize()[ii] -
           this->m_BlockWidth + 1;
@@ -741,7 +741,7 @@ void BlockMatcher<ImageType>
     //Get the start and end of the base iterator to ensure that
     //the nhoods are centred on the central nhood -
     //ITK makes the code look ugly. Sorry
-    for( int ii=0; ii<ImageType::ImageDimension; ++ii )
+    for( unsigned int ii=0; ii<ImageType::ImageDimension; ++ii )
     {
       nhoodStart[ii] = nhoodIterator.GetIndex()[ii] - ((this->m_NhoodWidth)/2) * this->m_BlockGap;
       nhoodEnd[ii] = nhoodStart[ii] + this->m_NhoodWidth * this->m_BlockGap;

--- a/src/mirorr/itkMirorrPyramidImplement.h
+++ b/src/mirorr/itkMirorrPyramidImplement.h
@@ -90,16 +90,6 @@ public:
   typedef /*typename*/ RegistrationType::TransformType             TransformType;
   typedef /*typename*/ itk::PyramidScheduleTuner<DIMENSION>        PyramidScheduleTunerType;
 
-  //! We also use ITK for a final fine tuning registration */
-  typedef itk::PowellOptimizer                                                   SecondOptimizerType;
-  //typedef itk::MattesMutualInformationImageToImageMetric< ImageType, ImageType > SecondMetricType;
-  typedef itk::ImageToImageMetric< ImageType, ImageType >                        SecondMetricType;
-  typedef itk::MattesMutualInformationImageToImageMetric< ImageType, ImageType > SecondMetricTypeMMI;
-  typedef itk::NormalizedCorrelationImageToImageMetric< ImageType, ImageType >   SecondMetricTypeNCC;
-  typedef itk::GradientDifferenceImageToImageMetric< ImageType, ImageType >      SecondMetricTypeGD;
-  typedef itk::MutualInformationImageToImageMetric< ImageType, ImageType >       SecondMetricTypeMI;
-  typedef itk::ImageRegistrationMethod< ImageType, ImageType >                   SecondRegistrationType;
-
   //! Define a multi-resolution image filter*/
   typedef itk::RecursiveMultiResolutionPyramidImageFilter<ImageType, ImageType > ImagePyramidFilterType;
 
@@ -134,9 +124,6 @@ public:
   void SetMovingImage( ImagePointer in ) { movingImage = in; }
   void SetFixedMask( MaskPointer in ) { fixedMask = in; }
   void SetMovingMask( MaskPointer in ) { movingMask = in; }
-  void SetLevelToChangeMethod( int in ) { m_LevelToChangeMethod = in; }
-  void SetUseBlockMatchingAlgorithm( bool in ) { m_UseBlockMatchingAlgorithm = in; }
-  void SetUseMutualInformationAlgorithm( bool in ) { m_UseMutualInformationAlgorithm = in; }
 
   RegistrationType::Pointer GetRegistrationObject() { return registration; }
 
@@ -147,22 +134,13 @@ public:
   //! interpolator_type is one of nn, linear, bspline, sinc.
   //! sinc use a radius of 5 (10 grid points) and the Welch window function
   ImagePointer GetResampledImage( /*typename*/ TransformType::Pointer transform,
-      bool resampling_moving_image = false, std::string interpolator_name="bspline" );
+                                               ImageType::Pointer image,
+                                               ImageType::Pointer ref_image,
+                                               std::string interpolator_name="bspline" );
   //! Reorient the fixed image into another space defined by the input transform. Does not resample, just update the header.
   ImagePointer GetReorientedImage( /*typename*/ TransformType::Pointer transform,
-      bool resampling_moving_image = false );
-
-  //! Set the metric for the secondary ITK registration
-  void SetSecondaryRegistrationMetricToMMI(); //Mattes mutual information
-  void SetSecondaryRegistrationMetricToNCC(); //Normalized cross-correlation
-  void SetSecondaryRegistrationMetricToGD();  //Gradient difference
-  void SetSecondaryRegistrationMetricToMI();  //Viola and Well mutual information (requires normalized input images)
-
-  //! Request a particular sample rate
-  void SetRequestedSampleRate( double in )
-  { m_RequestedSampleRate = std::max(0.0,std::min(1.0,in)); }
-  double GetRequestedSampleRate()
-  { return m_RequestedSampleRate; }
+    ImageType::Pointer image
+  );
 
 private:
   //! The moving and fixed images */
@@ -181,10 +159,6 @@ private:
   bool halveIterations;
   //! The minimum length of the image in any one dimension
   const double minLength;
-  //! The pyramid level when we switch from aladin registration to ITK
-  int m_LevelToChangeMethod;
-  bool m_UseBlockMatchingAlgorithm;
-  bool m_UseMutualInformationAlgorithm;
 
   //! Pointers to classes that do actual registration
   /*typename*/ InterpolatorType::Pointer         interpolator;
@@ -203,12 +177,6 @@ private:
 
   //! Object for deciding what schedule to use
   PyramidScheduleTunerType::Pointer m_PyramidScheduleTuner;
-
-  //! Extra objects used for final ITK registration
-  SecondOptimizerType::Pointer      m_SecondOptimizer;
-  SecondMetricType::Pointer         m_SecondMetric;
-  SecondRegistrationType::Pointer   m_SecondRegistration;
-  double m_RequestedSampleRate;
 
   void InitializeRegistrationObjet();
 

--- a/src/mirorr/itkMirorrPyramidWrapper.h
+++ b/src/mirorr/itkMirorrPyramidWrapper.h
@@ -41,6 +41,9 @@ PURPOSE.  See the above copyright notice for more information.
 #include <itkTransformBase.h>
 #include <itkResampleImageFilter.h>
 #include <vnl/vnl_cross.h>
+#include <itkMatrixOffsetTransformBase.h>
+#include "itkMirorrUtilities.h"
+
 #include "itkMirorrPyramidImplement.h"
 
 namespace itk
@@ -99,6 +102,11 @@ public:
     do_force_resample_fixed = false;
     do_force_resample_moving = false;
     do_initialise_tfm_to_centre_images = true;
+    crop_moving_X_vx = crop_moving_Y_vx = crop_fixed_X_vx = crop_fixed_Y_vx = 0;
+    movingToIdentityTfm = itk::AffineTransform<double,3>::New();
+    movingToIdentityTfm->SetIdentity();
+    fixedToIdentityTfm = itk::AffineTransform<double,3>::New();
+    fixedToIdentityTfm->SetIdentity();
   }
 
   MirorrType & GetRegistrationPyramidObject() { return mirorr; }
@@ -124,6 +132,15 @@ public:
   //! Do we attempt to reorient the image in the ARI direction?
   void SetDoReorientFixedInARI(bool in ) {do_reorient_fixed = in;}
   void SetDoReorientMovingInARI(bool in ) {do_reorient_moving = in;}
+  //! Precrop images by fixed no. voxels prior to registration
+  void SetCropMargins(unsigned int _moving_X_vx, unsigned int _moving_Y_vx,
+                      unsigned int _fixed_X_vx, unsigned int _fixed_Y_vx )
+  {
+    crop_moving_X_vx = _moving_X_vx;
+    crop_moving_Y_vx = _moving_Y_vx;
+    crop_fixed_X_vx = _fixed_X_vx;
+    crop_fixed_Y_vx = _fixed_Y_vx;
+  }
 
   //!Name of file string fixed image once it has been registered to moving
   //!image. If empty - no image is returned.
@@ -212,12 +229,17 @@ private:
   bool do_force_resample_fixed;
   bool do_force_resample_moving;
 
+  //! Maount to crop input images by in voxels
+  unsigned int crop_moving_X_vx, crop_moving_Y_vx, crop_fixed_X_vx, crop_fixed_Y_vx;
+
   bool do_initialise_tfm_to_centre_images;
 
   ImagePointer movingImage;
   ImagePointer fixedImage;
   MaskPointer movingMask;
   MaskPointer fixedMask;
+
+  itk::AffineTransform<double,3>::Pointer fixedToIdentityTfm, movingToIdentityTfm;
 
   //!Name of file string fixed image once it has been registered to moving
   //!image. If empty - no image is returned.

--- a/src/mirorr/itkMirorrRegistrationMethod.txx
+++ b/src/mirorr/itkMirorrRegistrationMethod.txx
@@ -578,9 +578,6 @@ MirorrRegistrationMethod<TMovingImage,TFixedImage>
   } break;
   }
 
-  //Get minimum image dimension
-  typedef typename TFixedImage::SizeType SizeType;
-
   this->SetupBlockMatcher();
 
   //Initial position

--- a/src/mirorr/itkMirorrUtilities.cxx
+++ b/src/mirorr/itkMirorrUtilities.cxx
@@ -1,0 +1,168 @@
+/*=========================================================================
+Program: mirorr
+Module: itkMirorrUtilities.cxx
+Author: Nicholas Dowson
+Created: 11 Jul 2017
+
+Copyright (c) 2009-17 CSIRO. All rights reserved.
+
+For complete copyright, license and disclaimer of warranty
+information see the LICENSE.txt file for details.
+
+This software is distributed WITHOUT ANY WARRANTY; without even
+the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+PURPOSE.  See the above copyright notice for more information.
+=========================================================================*/
+
+#include <itkImage.h>
+#include <itkMatrixOffsetTransformBase.h>
+#include "itkMirorrUtilities.h"
+#include <vnl/vnl_det.h>
+#include <itkLandmarkBasedTransformInitializer.h>
+#include <itkAffineTransform.h>
+
+namespace itk
+{
+namespace util
+{
+/**
+ * Get a transform that will rigidly transform an image to the identity space
+ * such that its origin is zero and its rotation matrix is the identity
+ * (although allowing permutations e.g. [0 1 0; 1 0 0; 0 0 1]
+ * MatrixOffsetTransformBase<double, 3,3> tfm =
+ *   GetTransformFromImageToIdentitySpace(
+ *     image->GetOrigin(), image->GetDirection() );
+ *
+ * This code is an adapted copy-paste from imgGetIdSpaceTfm
+ *
+ * @param origin Image Origin
+ * @param direction Image Direction Cosines
+ * @return Transform
+ */
+typedef Image<char,3> TImageType;
+AffineTransform<double, 3>::Pointer
+GetTransformFromImageToIdentitySpace(
+        Point<double,3> origin,
+        Matrix<double,3,3> direction,
+        Image<char,3>::SpacingType spacing,
+        Image<char,3>::SizeType size,
+        bool do_centre
+)
+{
+  //Read the input file and display its orientation
+  itk::Matrix<double,3,3> t_dir = direction;
+  t_dir.Fill(0.0);
+  for(int ii=0; ii<3; ++ii)
+  {
+    //Find maximum
+    std::vector<double> vals(3,0);
+    std::vector<bool> vsign(3,0);
+    for(int jj=0; jj<3; ++jj)
+    {
+      vals[jj] = fabs(direction[ii][jj]);
+      vsign[jj] = direction[ii][jj]>0;
+    }
+    int pos = std::max_element(vals.begin(),vals.end())-vals.begin();
+    t_dir[ii][pos] = vsign[pos] ? 1.0 : -1.0;
+  }
+
+  //BEWARE of negative determinants - they will flip your axes!
+  double det = fabs(vnl_det( t_dir.GetVnlMatrix() ));
+  for( int ii=0; ii<3; ++ii )
+    for( int jj=0; jj<3; ++jj )
+      t_dir[ii][jj] /= det;
+
+  itk::Matrix<double,3,3> out_dir = t_dir;
+
+  //Create the transform
+  typedef itk::Image<double,3> T_Image;
+  typedef T_Image::PointType T_Point;
+
+  //typedef itk::MatrixOffsetTransformBase<double, 3,3> T_Transform;
+  typedef itk::AffineTransform<double, 3> T_Transform;
+  typedef itk::LandmarkBasedTransformInitializer< T_Transform, T_Image, T_Image > T_LandmarkBasedTransformInitializer;
+
+//Create the transform
+  typedef itk::Image<double,3> T_Image;
+  typedef T_Image::PointType T_Point;
+
+  //typedef itk::MatrixOffsetTransformBase<double, 3,3> T_Transform;
+  typedef itk::AffineTransform<double, 3> T_Transform;
+  typedef itk::LandmarkBasedTransformInitializer< T_Transform, T_Image, T_Image > T_LandmarkBasedTransformInitializer;
+
+  T_LandmarkBasedTransformInitializer::LandmarkPointContainer fixedLandmarks, movingLandmarks;
+
+  T_Image::IndexType index[4];
+  for( unsigned int ii=0; ii<4; ++ii ) {
+    index[ii].Fill(0);
+    if (ii > 0)
+      index[ii][ii - 1] = 1;
+  }
+
+  //T_Image::SpacingType spacing;
+  //spacing.Fill(1);
+  //T_Image::SizeType size;
+  //size.Fill(10);
+
+  T_Image::RegionType region;
+  region.SetSize(size);
+
+  T_Image::Pointer img1 = T_Image::New();
+  img1->SetOrigin(origin);
+  img1->SetDirection(direction);
+  img1->SetSpacing(spacing);
+  img1->SetRegions(region);
+
+  T_Image::Pointer img2 = T_Image::New();
+  T_Image::PointType origin2;
+  for(int ii=0; ii<3; ++ii)
+    origin2[ii] = do_centre ? size[ii] * spacing[ii] * -0.5 : 0.0;
+  img2->SetOrigin(origin2);
+  img2->SetDirection(t_dir);
+  img2->SetSpacing(spacing);
+  img2->SetRegions(region);
+
+  for( unsigned int ii=0; ii<4; ++ii ) {
+    T_Point point;
+    img1->TransformIndexToPhysicalPoint(index[ii], point);
+    fixedLandmarks.push_back(point);
+    img2->TransformIndexToPhysicalPoint(index[ii], point);
+    movingLandmarks.push_back(point);
+  }
+
+  T_Transform::Pointer transform = T_Transform::New();
+
+  T_LandmarkBasedTransformInitializer::Pointer tfm_maker = T_LandmarkBasedTransformInitializer::New();
+  tfm_maker->SetFixedLandmarks(fixedLandmarks);
+  tfm_maker->SetMovingLandmarks(movingLandmarks);
+  tfm_maker->SetTransform(transform);
+  tfm_maker->InitializeTransform();
+
+  //Create the transform
+//  typedef itk::MatrixOffsetTransformBase<double, 3,3> T_Transform;
+//  T_Transform::Pointer transform = T_Transform::New();
+//
+//  T_Transform::InputPointType centre;
+//  centre.Fill(0.0);
+//  transform->SetCenter(centre);
+//
+//  T_Transform::OffsetType offset;
+//  for(unsigned int ii=0; ii<3; ++ii)
+//    offset[ii] = 0 - origin[ii];
+//  transform->SetOffset(offset);
+//
+//  for(unsigned int ii=0; ii<3; ++ii)
+//    offset[ii] = 0 - origin[ii];
+//
+//  T_Transform::MatrixType matrix;
+//  //matrix = out_dir.GetInverse() * direction.GetVnlMatrix(); //Working
+//  matrix = out_dir.GetVnlMatrix() * direction.GetInverse();
+//  transform->SetMatrix(matrix);
+
+  return transform;
+}
+
+}
+
+}
+

--- a/src/mirorr/itkMirorrUtilities.h
+++ b/src/mirorr/itkMirorrUtilities.h
@@ -1,0 +1,98 @@
+/*=========================================================================
+Program: mirorr
+Module: itkMirorrUtilities.h
+Author: Nicholas Dowson
+Created: 11 Jul 2017
+
+Copyright (c) 2009-17 CSIRO. All rights reserved.
+
+For complete copyright, license and disclaimer of warranty
+information see the LICENSE.txt file for details.
+
+This software is distributed WITHOUT ANY WARRANTY; without even
+the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+PURPOSE.  See the above copyright notice for more information.
+=========================================================================*/
+
+#ifndef MIRORRPROJECT_ITKMIRORRUTIL_H
+#define MIRORRPROJECT_ITKMIRORRUTIL_H
+
+#include <exception>
+#include <vector>
+#include <string>
+
+#include <itkImage.h>
+#include <itkMatrixOffsetTransformBase.h>
+#include <itkAffineTransform.h>
+
+#include <boost/algorithm/string.hpp>
+
+namespace itk
+{
+namespace util
+{
+/**
+ * Get a transform that will rigidly transform an image to the identity space
+ * such that its origin is zero and its rotation matrix is the identity
+ * (although allowing permutations e.g. [0 1 0; 1 0 0; 0 0 1]
+ * MatrixOffsetTransformBase<double, 3,3> tfm =
+ *   GetTransformFromImageToIdentitySpace(
+ *     image->GetOrigin(), image->GetDirection() );
+ *
+ * This code is an adapted copy-paste from imgGetIdSpaceTfm
+ *
+ * @param origin Image Origin
+ * @param direction Image Direction Cosines
+ * @return Transform
+ */
+typedef Image<char,3> TImageType;
+AffineTransform<double, 3>::Pointer
+GetTransformFromImageToIdentitySpace(
+        Point<double,3> origin,
+        Matrix<double,3,3> direction,
+        Image<char,3>::SpacingType spacing,
+        Image<char,3>::SizeType size,
+        bool do_centre = true
+);
+
+/**
+ * Parse an input string of a list of numbers to extract and convert individual elements.
+ * Several delimiters are supported including "x :,()="
+ * @tparam T The element type each element in the list should be converted to
+ * @param paramString The input string in format "el1,el2,el3".
+ * @param max_dimension The maximum length of the input values. Default is zero.
+ * @param out
+ */
+template <typename T>
+void
+parseInputToList( std::string paramString, unsigned int max_dimension, std::vector<T> & out)
+{
+  try {
+    std::vector<std::string> strs;
+    boost::split(strs, paramString, boost::is_any_of("x :,()=") );
+
+    std::vector<double> tout(std::min<unsigned int>(strs.size(), max_dimension), 0.0);
+    for( unsigned int ii=0; ii<max_dimension && ii<strs.size(); ++ii )
+    {
+      std::stringstream ss(strs[ii]);
+      ss >> tout[ii];
+    }
+    out.resize(tout.size());
+    if(out.size() < max_dimension)
+      out.resize(max_dimension, 0);
+    std::copy( tout.begin(), tout.end(), out.begin() );
+  }
+  catch( ... )
+  {
+    std::stringstream ss;
+    ss<< "Failed to parse input string: \""<< paramString
+      <<"\"\nExiting.\n";
+    throw std::runtime_error(ss.str());
+  }
+}
+
+}
+
+}
+
+#endif //MIRORRPROJECT_ITKMIRORRUTIL_H

--- a/src/mirorr/itkPyramidScheduleTuner.txx
+++ b/src/mirorr/itkPyramidScheduleTuner.txx
@@ -235,10 +235,16 @@ itk::PyramidScheduleTuner<DIMENSION>::UpdateVintage() //DRH - To delete once we'
       //Rely on moving sample rate to limit amount of downsampling
       m_FixedSchedule[level][dim] = fixedSampleRate; //std::min( maxFixedSampleRate, fixedSampleRate);
     }
-
-    if( 0 == m_LevelMin ) m_LevelMin = 1;
-    if( 0 == m_LevelMax ) m_LevelMax = m_FixedSchedule.rows();
   }
+
+  if( 0 == m_LevelMin )
+    m_LevelMin = 1;
+  else if( 0 > m_LevelMin )
+    m_LevelMin = m_FixedSchedule.rows() + m_LevelMin;
+  if( 0 == m_LevelMax )
+    m_LevelMax = m_FixedSchedule.rows();
+  else if( 0 > m_LevelMax )
+    m_LevelMax = m_FixedSchedule.rows() + m_LevelMax;
 }
 
 // Return the number of time 'n' that 'base' can be doubled while still being smaller than dimension


### PR DESCRIPTION
Internalised the use of an identity space when registering.
Cleaned up the interface and removed legacy ITK based registration.
Added ability to pre-crop images.
Fixed default to do first pyramid level only as this often gives good results and is fast.