### PR TITLE
[FIX] Some issues preventing building on later gcc.

### DIFF
--- a/src/mirorr/itkMirorrPyramidImplement.txx
+++ b/src/mirorr/itkMirorrPyramidImplement.txx
@@ -385,7 +385,7 @@ MirorrPyramidImplement::GetInterpolatorFromString(std::string interpolator_name)
     eInterpolatorType = SINC;
   } else {
     std::cout << "GetInterpolatorFromString(...) Unspecified or unknown interpolator name. "
-    << "Defaulting to bspline." << std::cout;
+    << "Defaulting to bspline." << std::endl;
     eInterpolatorType = BSPLINE;
   }
 

--- a/src/mirorr/itkMirorrRegistrationMethod.txx
+++ b/src/mirorr/itkMirorrRegistrationMethod.txx
@@ -25,6 +25,7 @@ PURPOSE.  See the above copyright notice for more information.
 #include "itkBlockMatcher.h"
 #include "itkBlockMatcherThreaded.h"
 #include "itkEuler3DTransform.h"
+#include "itkIOUtils.h"
 
 #ifdef USE_OPENCL
   #include "itkBlockMatcherGPU.h"


### PR DESCRIPTION
Not sure why piping std::cout ever worked.

Explicitly including itkIOUtils was required.

Tested with ITK 4.13, Boost 1.67, gcc 7.3